### PR TITLE
重构 CoreLocationKit 定位策略与参数控制

### DIFF
--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -200,23 +200,6 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
     /// 错误信息订阅对象
     private let errorSubject = CurrentValueSubject<Swift.Error?, Never>(nil)
     
-    /**
-     允许开发者修改定位精度和距离过滤器
-     
-     - parameter accuracy: 定位精度（默认值 `kCLLocationAccuracyBest`）
-     - parameter distance: 触发 `didUpdateLocations` 事件的最小移动距离（默认值 `35` 米）
-     */
-    public func setLocationAccuracy(_ accuracy: CLLocationAccuracy = kCLLocationAccuracyBest,
-                                    distanceFilter distance: CLLocationDistance = 35) {
-        locationManager.desiredAccuracy = accuracy
-        locationManager.distanceFilter = distance
-        
-        // 改完精度后，若当前已具备发起条件（服务开 + 已授权）则重启持续更新让新精度生效。
-        // 授权判断复用 currentLocationReadiness（读 subject、含平台白名单），不再瞬时读实例属性、不再各写一份白名单。
-        if currentLocationReadiness() == nil {
-            restartUpdatingLocation()
-        }
-    }
 }
 
 // MARK: - CLLocationManagerDelegate
@@ -498,23 +481,6 @@ extension CoreLocationKit {
 
 //MARK: - 内部方法
 extension CoreLocationKit {
-    ///重新获取定位数据
-    private func restartUpdatingLocation() {
-        guard CLLocationManager.locationServicesEnabled() else {
-            print("⚠️ 定位服务未启用，无法重启 `startUpdatingLocation()`")
-            return
-        }
-        locationManager.stopUpdatingLocation()
-        locationManager.startUpdatingLocation()
-        
-        
-        if CLLocationManager.headingAvailable() {
-            locationManager.startUpdatingHeading()
-        } else {
-            print("⚠️ 设备不支持方向数据，跳过 `startUpdatingHeading()`")
-        }
-    }
-    
     /**
      在授权状态尚未决定（`notDetermined`）时发起一次定位授权请求。
      
@@ -597,7 +563,7 @@ extension CoreLocationKit {
         if shouldRun {
             locationManager.startUpdatingLocation()
 #if os(iOS)
-            // heading 仅 iOS 可用；iOS 内再以 headingAvailable() 判定设备磁力计能力，与 restartUpdatingLocation 一致
+            // heading 仅 iOS 可用；以 headingAvailable() 判定设备磁力计能力
             if CLLocationManager.headingAvailable() {
                 locationManager.startUpdatingHeading()
             }

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -77,24 +77,25 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
      `CLLocationManager` 实例，管理设备的定位服务。
      
      - Important: 该对象是 `CoreLocationKit` 的核心组件，负责所有的 GPS 数据更新和权限管理。
+     - Important: 刻意保持 `internal`（非 `public`）——对外暴露会让任何调用方绕开 SDK 的机制层（如 A1 的订阅者门槛、精度参数化）直接操作原始 manager，使封装失去意义。SDK 尚未覆盖的能力应通过扩展公开接口补齐，而非绕道直接访问此对象。
      - Warning: 请确保 `Info.plist` 文件中已正确配置 `NSLocationWhenInUseUsageDescription` 或 `NSLocationAlwaysUsageDescription`，否则调用 `requestLocation()` 可能导致崩溃。
      - Note: `CLLocationManager` 需要在主线程使用，否则部分 API 可能无法正常工作。
      */
-    public let locationManager: CLLocationManager
+    internal let locationManager: CLLocationManager
     
     /**
      发布设备当前位置的 `Combine` 流。
-
+     
      - Important: **订阅此 publisher 即驱动持续定位**——已授权前提下，有订阅者时启动 `startUpdatingLocation` 持续推送，取消订阅（或无任何订阅者）则停止；无人订阅时 SDK 不进行持续定位（要不要持续由调用方订阅与否决定，机制/策略分离）。
      - Attention: 持续定位增加电量消耗。只需「当前位置一次」用 `requestCurrentLocation(timeout:)`；只需「读最近缓存」用 `currentLocation`。
      - Returns: `CLLocation?`，尚无位置信息时为 `nil`。
      - Example:
-```swift
+     ```swift
      locationKit.locationPublisher
      .sink { location in
      print("当前位置: \(String(describing: location))")
      }
-```
+     ```
      */
     public var locationPublisher: AnyPublisher<CLLocation?, Never> {
         locationSubject

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -668,7 +668,7 @@ private final class SingleLocationRequest: NSObject, CLLocationManagerDelegate {
      创建并立即发起一次定位请求。
  
      - Parameters:
-       - desiredAccuracy: 期望精度，沿用主实例的精度设置以保持一致。
+     - desiredAccuracy: 期望精度，由调用方（`CoreLocationKit.makeSingleLocationRequest`）显式传入，与主实例状态完全独立，不借用、不受其影响。
        - timeout: 超时时限（秒）。超时后以 `LocationError.timeout` 失败，不重试。
        - completion: 唯一结果回调（成功位置 / 失败错误）。
        - onFinish: 请求终结后调用，回传本实例自身，供持有者精确解除强引用。

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -382,7 +382,7 @@ extension CoreLocationKit {
                     return Fail(error: blocker).eraseToAnyPublisher()
                 }
                 // 就绪且在白名单 → 发起单次定位；测量阶段超时由 SingleLocationRequest 内部计时负责
-                return self.makeSingleLocationRequest(timeout: timeout)
+                return self.makeSingleLocationRequest(timeout: timeout, accuracy: accuracy)
             }
             .handleEvents(receiveOutput: { [weak self] location in
                 //单次成功也回写快照，使 currentLocation 独立于持续定位订阅——A1 后无人订阅时持续更新不跑，靠此保鲜。
@@ -527,28 +527,26 @@ extension CoreLocationKit {
     }
     
     /**
-     创建并发起一次独立的单次定位请求，桥接为 Combine publisher。
-     
-     封装 `SingleLocationRequest` 的生命周期：请求存续期间由 `pendingSingleRequests` 维持强引用，终结后自动解除。仅由 `requestCurrentLocation(timeout:)` 在授权就绪后调用。
+     封装 `SingleLocationRequest` 的生命周期：请求存续期间由 `pendingSingleRequests` 维持强引用，终结后自动解除。仅由 `requestCurrentLocation(timeout:accuracy:)` 在授权就绪后调用。
      
      - Parameter timeout: 单次测量的超时时限（秒），透传给 `SingleLocationRequest` 内部计时。
+     - Parameter accuracy: 本次单次测量使用的定位精度，由调用方（`requestCurrentLocation`）显式传入，不借用主实例的 `locationManager.desiredAccuracy`。
      - Returns: 发出单个 `CLLocation` 后完成的 publisher；失败时发出错误。
      */
-    private func makeSingleLocationRequest(timeout: TimeInterval) -> AnyPublisher<CLLocation, Swift.Error> {
+    private func makeSingleLocationRequest(timeout: TimeInterval, accuracy: CLLocationAccuracy) -> AnyPublisher<CLLocation, Swift.Error> {
         Future<CLLocation, Swift.Error> { [weak self] promise in
             guard let self = self else {
                 promise(.failure(LocationError.locationUnavailable))
                 return
             }
             let request = SingleLocationRequest(
-                desiredAccuracy: self.locationManager.desiredAccuracy,
+                desiredAccuracy: accuracy,
                 timeout: timeout,
                 completion: { result in
                     promise(result)
                 },
                 onFinish: { [weak self] finished in
-                    // 终结时由 SingleLocationRequest 回传自身，据此解除持有——
-                    // 不再用外部 var 捕获，从根上消除「实例 → onFinish → 捕获变量 → 实例」的自持有环
+                    // 终结时由 SingleLocationRequest 回传自身，据此解除持有
                     self?.pendingSingleRequests.remove(finished)
                 }
             )

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -62,7 +62,7 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
         // 授权只是其中一个事件源，locationPublisher 订阅数跨 0 是另一个。
         authorizationStatusPublisher
             .removeDuplicates()
-            // 收口主线程，与订阅计数源统一，updateContinuousUpdates 恒在 main
+        // 收口主线程，与订阅计数源统一，updateContinuousUpdates 恒在 main
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 // 状态由方法内部读 currentAuthorizationStatus，不再传参
@@ -115,10 +115,10 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
      获取当前设备的最新位置信息。
      
      - Important: 该属性 **仅返回最新缓存的位置数据**，不会主动触发新的定位请求。
-      - Returns: `CLLocation?`，如果设备尚未提供位置信息，则返回 `nil`。
-      - Note: 缓存由两条路径共同保鲜——「订阅 `locationPublisher` 期间的持续更新」与「`requestCurrentLocation` 单次请求成功」，故其新鲜度不依赖是否开着持续定位；即便无人订阅，只要单次请求成功过，此处即有值。
-      - Note: 若希望主动请求最新位置，请使用 `requestCurrentLocation(timeout:)` 方法。
-      */
+     - Returns: `CLLocation?`，如果设备尚未提供位置信息，则返回 `nil`。
+     - Note: 缓存由两条路径共同保鲜——「订阅 `locationPublisher` 期间的持续更新」与「`requestCurrentLocation` 单次请求成功」，故其新鲜度不依赖是否开着持续定位；即便无人订阅，只要单次请求成功过，此处即有值。
+     - Note: 若希望主动请求最新位置，请使用 `requestCurrentLocation(timeout:)` 方法。
+     */
     public var currentLocation: CLLocation? {
         locationSubject.value
     }
@@ -147,7 +147,7 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
     public var altitudePublisher: AnyPublisher<CLLocationDistance, Never> {
         altitudeSubject.eraseToAnyPublisher()
     }
-
+    
     /// 当前方向数据
     public var currentHeading: CLHeading? {
         headingSubject.value
@@ -169,18 +169,18 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
     /// 持续定位启停取决于「授权就绪 AND 此值 > 0」——无人订阅则不空转持续定位。
     private var locationSubscriberCount = 0
     /**
-    进行中的单次定位请求。
-       requestCurrentLocation(timeout:)` 每次创建一个 `SingleLocationRequest` 并暂存于此，以在请求存续期间维持强引用（否则 delegate 回调不触发）；请求终结后自动移除。
-    */
+     进行中的单次定位请求。
+     requestCurrentLocation(timeout:)` 每次创建一个 `SingleLocationRequest` 并暂存于此，以在请求存续期间维持强引用（否则 delegate 回调不触发）；请求终结后自动移除。
+     */
     private var pendingSingleRequests = Set<SingleLocationRequest>()
     
     /// 授权状态订阅对象（默认值 `notDetermined`，防止 `nil`）
     private let authorizationStatusSubject: CurrentValueSubject<CLAuthorizationStatus, Never> = {
-        #if os(iOS)
+#if os(iOS)
         return CurrentValueSubject(CLLocationManager.authorizationStatus())
-        #elseif os(macOS)
+#elseif os(macOS)
         return CurrentValueSubject(CLLocationManager().authorizationStatus)
-        #endif
+#endif
     }()
     /// 内部长期订阅容器：持有「授权状态驱动持续更新启停」等跟随单例生命周期的订阅
     private var subscriptions = Set<AnyCancellable>()
@@ -210,8 +210,6 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
             restartUpdatingLocation()
         }
     }
-    
-    
 }
 
 // MARK: - CLLocationManagerDelegate
@@ -223,7 +221,7 @@ extension CoreLocationKit {
             errorSubject.send(error)
             return
         }
-
+        
         switch clError.code {
         case .locationUnknown:
             print("位置暂时不可用，等待系统自动重试")

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -87,22 +87,29 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
      发布设备当前位置的 `Combine` 流。
      
      - Important: **订阅此 publisher 即驱动持续定位**——已授权前提下，有订阅者时启动 `startUpdatingLocation` 持续推送，取消订阅（或无任何订阅者）则停止；无人订阅时 SDK 不进行持续定位（要不要持续由调用方订阅与否决定，机制/策略分离）。
-     - Attention: 持续定位增加电量消耗。只需「当前位置一次」用 `requestCurrentLocation(timeout:)`；只需「读最近缓存」用 `currentLocation`。
+     - Attention: 持续定位增加电量消耗。只需「当前位置一次」用 `requestCurrentLocation(timeout:accuracy:)`；只需「读最近缓存」用 `currentLocation`。
+     - Parameter accuracy: 定位精度，默认 `kCLLocationAccuracyBest`。在首次订阅触发时写入 `locationManager.desiredAccuracy`。
+     - Parameter distanceFilter: 触发位置上报的最小移动距离（米），默认 `35`。同上，在订阅触发时写入。
      - Returns: `CLLocation?`，尚无位置信息时为 `nil`。
+     - Note: 精度/距离过滤是显式参数而非可变共享状态——避免不相关调用方之间隔空互相影响。若多个订阅者声明不同值，以最近一次触发订阅时的赋值为准（与改动前的语义一致，未新增也未解决多值冲突，仅是表达方式的转移）。
      - Example:
      ```swift
-     locationKit.locationPublisher
+     locationKit.locationPublisher()
      .sink { location in
      print("当前位置: \(String(describing: location))")
      }
      ```
      */
-    public var locationPublisher: AnyPublisher<CLLocation?, Never> {
+    public func locationPublisher(accuracy: CLLocationAccuracy = kCLLocationAccuracyBest, distanceFilter: CLLocationDistance = 35) -> AnyPublisher<CLLocation?, Never> {
         locationSubject
             .handleEvents(
                 receiveSubscription: { [weak self] _ in
-                    // handleEvents 钩子可能在任意线程触发，收口主线程保证计数只在 main 读写
-                    DispatchQueue.main.async { self?.locationSubscriberCountChanged(by: 1) }
+                    // handleEvents 钩子可能在任意线程触发，收口主线程保证赋值与计数一致收口
+                    DispatchQueue.main.async {
+                        self?.locationManager.desiredAccuracy = accuracy
+                        self?.locationManager.distanceFilter = distanceFilter
+                        self?.locationSubscriberCountChanged(by: 1)
+                    }
                 },
                 receiveCancel: { [weak self] in
                     DispatchQueue.main.async { self?.locationSubscriberCountChanged(by: -1) }

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -516,8 +516,9 @@ extension CoreLocationKit {
      - Note: 判断依据取自 `currentAuthorizationStatus`（即 `authorizationStatusSubject` 当前值）
      - Note: 可安全重复调用——系统对已决定授权的 App 会忽略重复的 `requestWhenInUseAuthorization()`（不弹框、无副作用）；仅在 `notDetermined` 时正常弹出授权框。
      - Important: `requestWhenInUseAuthorization()` 要求在主线程调用，故派发至主队列。
+     - Note: 触发时机由调用方决定（机制/策略分离）——`requestCurrentLocation` 不再内部自动调用，何时请求授权、要不要请求，交由调用方编排。
      */
-    private func requestAuthorizationIfNeeded() {
+    public func requestAuthorizationIfNeeded() {
         // 仅在「尚未决定」时请求；已授权 / 已拒绝状态下无需打扰
         guard currentAuthorizationStatus == .notDetermined else { return }
         // requestWhenInUseAuthorization 要求主线程调用

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -24,32 +24,30 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
      初始化 `CoreLocationKit` 单例，统一管理 `CoreLocation` 相关的定位服务。
      
      - Important: 该类为单例模式，不能手动初始化，必须通过 `CoreLocationKit.shared` 访问。
-     - Attention: 仅在 `shared` 访问时初始化，所有定位服务在 `init` 时即开启。
+     - Attention: 仅在 `shared` 访问时初始化。`init` 本身不触发授权请求、不开始任何定位——是否请求授权、是否持续定位，均由调用方通过 `requestAuthorizationIfNeeded()` / 订阅 `locationPublisher(...)` 显式决定（机制/策略分离）。
      - Bug: 在 iOS 14 及以上，`requestWhenInUseAuthorization()` 可能需要在主线程调用，否则可能无效。
      - Warning: 请确保在 `Info.plist` 文件中添加 `NSLocationWhenInUseUsageDescription` 或 `NSLocationAlwaysUsageDescription`，否则 `requestWhenInUseAuthorization()` 将导致崩溃。
      - Requires: 适用于 `iOS 13.0+`，需要 `CoreLocation` 框架支持。
-     - Remark: `desiredAccuracy` 影响耗电量，`distanceFilter` 影响更新频率，合理设置可优化性能。
+     - Remark: `desiredAccuracy` 影响耗电量，`distanceFilter` 影响更新频率；两者不再通过 `init` 定制，改为在 `locationPublisher(accuracy:distanceFilter:)` / `requestCurrentLocation(accuracy:)` 每次发起定位时显式声明。
      - Note: `distanceFilter = kCLDistanceFilterNone` 表示始终触发 `didUpdateLocations`，不建议长期使用。
-     - Precondition: 必须确保 `locationServicesEnabled()` 返回 `true`，否则 `requestLocation()` 无效。
-     - Postcondition: 在初始化完成后，将立即请求授权并开始定位。
+     - Precondition: 必须确保 `CLLocationManager.locationServicesEnabled()` 返回 `true`，否则任何定位请求均无效。
+     - Postcondition: 初始化完成后不会自动请求授权或开始定位，处于完全被动状态，等待调用方显式触发。
      
      # 使用示例
      ```swift
      let locationKit = CoreLocationKit.shared
-     locationKit.setLocationAccuracy(.nearestTenMeters, distanceFilter: 10)
+     locationKit.requestAuthorizationIfNeeded()
+     locationKit.locationPublisher(accuracy: kCLLocationAccuracyNearestTenMeters, distanceFilter: 10)
+     .sink { location in print(location ?? "暂无位置") }
      ```
-     
-     - parameter accuracy: 定位精度，默认为 `kCLLocationAccuracyBest`，建议根据业务需求调整。
-     - parameter distanceFilter: 触发 `didUpdateLocations` 事件的最小移动距离，默认 `35` 米，适用于一般导航需求。
      */
-    private init(accuracy: CLLocationAccuracy = kCLLocationAccuracyBest,
-                 distanceFilter: CLLocationDistance = 35) {
+    private override init() {
         locationManager = CLLocationManager()
         super.init()
         
         locationManager.delegate = self
-        locationManager.desiredAccuracy = accuracy
-        locationManager.distanceFilter = distanceFilter
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.distanceFilter = 35
         
         // 空窗期可能是 notDetermined，由 didChangeAuthorization 后续更新为真值。
         // iOS 沿用静态方法、macOS 用实例属性，是两平台读取 API 的固有差异。

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -334,7 +334,7 @@ extension CoreLocationKit {
      主动触发定位硬件获取**一个新的**位置，与「读取缓存快照」（`currentLocation`）和「持续订阅」（`locationPublisher`）是三种不同语义，互不替代。
      
      实现要点：
-     - **授权状态异步**：不在调用瞬间硬读授权状态（进程启动有「空窗期」，瞬时读会得到假 `notDetermined`），而是订阅授权状态、等其「就绪」（非 `notDetermined`）后再决策；尚未决定时先经收敛入口触发授权请求。已授权时因 `CurrentValueSubject` 重放当前值而零额外等待。
+     - **授权状态异步**：不在调用瞬间硬读授权状态（进程启动有「空窗期」，瞬时读会得到假`notDetermined`），而是订阅授权状态、等其「就绪」（非 `notDetermined`）后再决策；尚未决定时先经收敛入口触发授权请求。已授权时因 `CurrentValueSubject` 重放当前值而零额外等待。
      - 使用一个**独立的** `CLLocationManager`（封装在 `SingleLocationRequest` 内）执行本次请求，与主实例的持续定位完全隔离，不会干扰正在订阅 `locationPublisher` 的使用者。
      - 取得首个有效位置后立即停止该独立 manager，信守「取一次、省电」的语义。
      - 不自动重试。

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -124,7 +124,7 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
      - Important: 该属性 **仅返回最新缓存的位置数据**，不会主动触发新的定位请求。
      - Returns: `CLLocation?`，如果设备尚未提供位置信息，则返回 `nil`。
      - Note: 缓存由两条路径共同保鲜——「订阅 `locationPublisher` 期间的持续更新」与「`requestCurrentLocation` 单次请求成功」，故其新鲜度不依赖是否开着持续定位；即便无人订阅，只要单次请求成功过，此处即有值。
-     - Note: 若希望主动请求最新位置，请使用 `requestCurrentLocation(timeout:)` 方法。
+     - Note: 若希望主动请求最新位置，请使用 `requestCurrentLocation(timeout:accuracy:)` 方法。
      */
     public var currentLocation: CLLocation? {
         locationSubject.value
@@ -177,7 +177,7 @@ public final class CoreLocationKit: NSObject, ObservableObject, CLLocationManage
     private var locationSubscriberCount = 0
     /**
      进行中的单次定位请求。
-     requestCurrentLocation(timeout:)` 每次创建一个 `SingleLocationRequest` 并暂存于此，以在请求存续期间维持强引用（否则 delegate 回调不触发）；请求终结后自动移除。
+     `requestCurrentLocation(timeout:accuracy:)` 每次创建一个 `SingleLocationRequest` 并暂存于此，以在请求存续期间维持强引用（否则 delegate 回调不触发）；请求终结后自动移除。
      */
     private var pendingSingleRequests = Set<SingleLocationRequest>()
     
@@ -449,7 +449,7 @@ extension CoreLocationKit {
     /**
      校验发起定位请求的前置条件（纯函数）。
      
-     不读取任何系统状态，仅依据传入的参数做判定，因此结果完全确定、可独立单元测试，并被 `requestCurrentLocation(timeout:)`、`currentLocationReadiness()` 共用，确保「授权白名单」只在此处定义一份，不会在多处各写一份而走样。
+     不读取任何系统状态，仅依据传入的参数做判定，因此结果完全确定、可独立单元测试，并被 `requestCurrentLocation(timeout:accuracy:)`、`currentLocationReadiness()` 共用，确保「授权白名单」只在此处定义一份，不会在多处各写一份而走样。
      
      - Parameters:
      - servicesEnabled: 设备定位服务总开关是否开启。
@@ -487,7 +487,7 @@ extension CoreLocationKit {
      
      - Returns: 满足条件返回 `nil`；否则返回阻碍发起的具体 `LocationError`。
      - Note: 仅做「能否发起」的快照判定，不触发定位、也不等待授权就绪。
-     - Important: 这是同步快照——启动空窗期内 subject 尚为 `notDetermined` 时会如实反映该状态、并非系统真值；需要可靠结果应走会「等就绪」的 `requestCurrentLocation(timeout:)`。
+     - Important: 这是同步快照——启动空窗期内 subject 尚为 `notDetermined` 时会如实反映该状态、并非系统真值；需要可靠结果应走会「等就绪」的 `requestCurrentLocation(timeout:accuracy:)`。
      */
     public func currentLocationReadiness() -> LocationError? {
         // 授权状态统一取自 subject（单一真相源），不再瞬时读实例属性——后者在启动空窗期会得到假 notDetermined。
@@ -674,7 +674,7 @@ extension CoreLocationKit {
 /**
  一次性定位请求的执行器。
  
- 用于支撑 `CoreLocationKit.requestCurrentLocation(timeout:)` 的「请求一次」语义。每次单次请求都创建一个独立实例，持有自己**独立的** `CLLocationManager`，与 `CoreLocationKit` 主实例的持续定位（`locationPublisher` 背后的 manager）完全隔离。
+ 用于支撑 `CoreLocationKit.requestCurrentLocation(timeout:accuracy:)`的「请求一次」语义。每次单次请求都创建一个独立实例，持有自己**独立的** `CLLocationManager`，与 `CoreLocationKit` 主实例的持续定位（`locationPublisher` 背后的 manager）完全隔离。
  
  - Important: 采用独立 manager 的根本原因——单次请求拿到位置后需要 `stop`，若复用主 manager 的 `stopUpdatingLocation()`，会**误停主实例的持续更新**，掐断其它正在订阅 `locationPublisher` 的使用者。独立实例彻底规避此冲突。
  - Important: 本类必须在请求存续期间被强引用持有（由 `CoreLocationKit` 用集合持有），否则方法返回后实例即释放，`CLLocationManagerDelegate` 回调永不触发。请求终结（成功 / 失败 / 超时）后通过 `onFinish` 回调通知持有者解除持有。

--- a/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
+++ b/Sources/NavigationKit/CoreLocationKit/CoreLocationKit.swift
@@ -331,12 +331,13 @@ extension CoreLocationKit {
      主动触发定位硬件获取**一个新的**位置，与「读取缓存快照」（`currentLocation`）和「持续订阅」（`locationPublisher`）是三种不同语义，互不替代。
      
      实现要点：
-     - **授权状态异步**：不在调用瞬间硬读授权状态（进程启动有「空窗期」，瞬时读会得到假`notDetermined`），而是订阅授权状态、等其「就绪」（非 `notDetermined`）后再决策；尚未决定时先经收敛入口触发授权请求。已授权时因 `CurrentValueSubject` 重放当前值而零额外等待。
-     - 使用一个**独立的** `CLLocationManager`（封装在 `SingleLocationRequest` 内）执行本次请求，与主实例的持续定位完全隔离，不会干扰正在订阅 `locationPublisher` 的使用者。
+     - **授权状态异步**：不在调用瞬间硬读授权状态（进程启动有「空窗期」，瞬时读会得到假 `notDetermined`），而是订阅授权状态、等其「就绪」（非 `notDetermined`）后再决策。是否请求授权由调用方决定（见 `requestAuthorizationIfNeeded`）——未主动请求过时，状态停在 `notDetermined`，下方等待链会在 timeout 后正常失败，与「已拒绝」殊途同归。已授权时因 `CurrentValueSubject` 重放当前值而零额外等待。
+     - 使用一个**独立的** `CLLocationManager`（封装在 `SingleLocationRequest` 内）执行本次请求，与主实例的持续定位完全隔离，不会干扰正在订阅 `locationPublisher` 的使用者；精度也随参数显式传入、不借用主实例状态，隔离彻底。
      - 取得首个有效位置后立即停止该独立 manager，信守「取一次、省电」的语义。
      - 不自动重试。
      
      - Parameter timeout: 超时时限（秒），默认 10。涵盖「等待授权就绪」与「单次定位测量」——任一阶段超时均以 `LocationError.timeout` 失败。常态（已授权）下等待就绪近乎瞬时，timeout 实际作用于测量阶段。
+     - Parameter accuracy: 本次请求的定位精度，默认 `kCLLocationAccuracyBest`。仅作用于本次独立请求，不影响 `locationPublisher` 或其它并发的单次请求。
      - Returns: 发出**单个** `CLLocation` 后立即完成的 publisher；失败时发出错误。
      - Note: 是否重试由调用方决定——可对返回值施加 `.retry(_:)`。SDK 不内置重试。
      - Note: 若只需「此刻的缓存位置、可能为 nil」，应改用 `currentLocation` 属性，零等待零耗电；若需持续跟踪，应订阅 `locationPublisher`。
@@ -351,27 +352,24 @@ extension CoreLocationKit {
      .store(in: &subscriptions)
      ```
      */
-    public func requestCurrentLocation(timeout: TimeInterval = 10) -> AnyPublisher<CLLocation, Swift.Error> {
+    public func requestCurrentLocation(timeout: TimeInterval = 10,
+                                       accuracy: CLLocationAccuracy = kCLLocationAccuracyBest) -> AnyPublisher<CLLocation, Swift.Error> {
         // 步骤1：服务总开关无空窗期，可瞬时判断；关闭则直接失败，不必进入等待
         guard CLLocationManager.locationServicesEnabled() else {
             return Fail(error: LocationError.locationServicesDisabled).eraseToAnyPublisher()
         }
         
-        // 步骤2：尚未决定授权时经收敛入口发起授权请求；已决定则为 no-op
-        requestAuthorizationIfNeeded()
-        
-        // 步骤3~5：订阅授权状态，等其「就绪」（非 notDetermined）后再决策。
-        // 不再瞬时读 status —— 授权状态是异步的，启动空窗期内瞬时读会得到假 notDetermined。
-        // authorizationStatusSubject 是 CurrentValueSubject，订阅即重放当前值：已授权时当前值即真值，
-        // filter 立即放行、零额外等待；空窗期当前值为 notDetermined，被滤掉，待 didChangeAuthorization 送真值后再放行。
+        // 步骤2：订阅授权状态，等其「就绪」（非 notDetermined）后再决策。
+        // 是否请求授权由调用方决定（见 requestAuthorizationIfNeeded）——未主动请求过时，状态停在
+        // notDetermined，下方等待链会在 timeout 后正常失败，与「已拒绝」殊途同归。
         return authorizationStatusPublisher
             .filter { $0 != .notDetermined }
             .first()
-            .setFailureType(to: Swift.Error.self)            // Never → Error，以承接下方 timeout 与 flatMap 的错误流
+            .setFailureType(to: Swift.Error.self)
             .timeout(
                 .seconds(timeout),
                 scheduler: DispatchQueue.main,
-                customError: { LocationError.timeout }        // 等就绪超时：回调迟迟不到则失败，不无限挂起
+                customError: { LocationError.timeout }
             )
             .flatMap { [weak self] status -> AnyPublisher<CLLocation, Swift.Error> in
                 guard let self = self else {

--- a/Sources/NavigationKit/NavigationKit.swift
+++ b/Sources/NavigationKit/NavigationKit.swift
@@ -26,45 +26,45 @@ extension NavigationKit {
     private static var isElevationPipelineStarted = false
     
     /**
-         启动默认的海拔计算数据管道，将 `CoreLocationKit` 的位置数据自动接入 `ElevationManager`。
-         
-         - Important: 此方法为**幂等**设计，多次调用仅第一次生效，后续调用将被忽略，不会重复建立订阅。
-         - Attention: 该默认管道基于 `CoreLocationKit.shared.locationPublisher` 提供的位置数据，使用 `CLLocation.distance(from:)` 计算相邻两点间的水平距离，以用于坡度与累计爬升/下降的计算。
-         - Bug: 如果上层在未正确配置定位权限或未启用定位服务的情况下调用本方法，可能导致 `locationPublisher` 长时间无数据推送，从而无法更新海拔相关统计。
-         - Warning: 本方法**不会**主动请求定位权限或启动硬件，仅建立对 `locationPublisher` 的订阅；上层仍需确保 `CoreLocationKit` 已按需初始化并具有有效的定位权限。
-         - Requires: 需要在工程中集成 `CoreLocationKit` 与 `NavigationCoreKit`，并保证`CoreLocationKit.shared.locationPublisher` 能够稳定推送 `CLLocation` 数据。
-         - Remark: 该方法适用于“快速接入”的场景，例如公路导航、骑行记录等，不需要自行管理海拔处理管线的应用。
-         - Note: 若对水平距离计算有更高精度要求（如基于轨迹纠偏、地图匹配等），建议**不要使用本默认管道**，而是在上层自行调用`ElevationManager.processAltitudeSample(rawAltitude:horizontalDistance:)` 进行更精细控制。
-         - Precondition: `CoreLocationKit.shared` 已完成初始化，且应用的 Info.plist 中已配置必要的定位权限字段（如 `NSLocationWhenInUseUsageDescription` 等）。
-         - Postcondition: 成功调用后，`ElevationManager` 将随位置更新自动计算：
-           - 平滑海拔（`smoothedAltitude`）
-           - 累计爬升（`elevationGain`）
-           - 累计下降（`elevationLoss`）
-           - 当前坡度（`gradient`，单位：百分比 %）
-         
-         # 使用示例
-         ```swift
-         // 在 App 启动或导航功能初始化时调用一次
-         NavigationKit.startDefaultElevationPipeline()
-         
-         // 在 ViewModel 中订阅计算结果
-         NavigationKit.elevationManager.$elevationGain
-             .receive(on: RunLoop.main)
-             .sink { gain in
-                 print("当前累计爬升：\(gain) m")
-             }
-             .store(in: &subscriptions)
-         ```
-         
-         - parameter 无: 本方法不接受任何参数，内部直接使用 `CoreLocationKit.shared.locationPublisher`。
-         - Returns: 无返回值。
-         - Throws: 不抛出错误，所有异常情况通过日志或上层状态观察处理。
-         */
+     启动默认的海拔计算数据管道，将 `CoreLocationKit` 的位置数据自动接入 `ElevationManager`。
+     
+     - Important: 此方法为**幂等**设计，多次调用仅第一次生效，后续调用将被忽略，不会重复建立订阅。
+     - Attention: 该默认管道基于 `CoreLocationKit.shared.locationPublisher()` 提供的位置数据，使用 `CLLocation.distance(from:)` 计算相邻两点间的水平距离，以用于坡度与累计爬升/下降的计算。
+     - Bug: 如果上层在未正确配置定位权限或未启用定位服务的情况下调用本方法，可能导致 `locationPublisher` 长时间无数据推送，从而无法更新海拔相关统计。
+     - Warning: 本方法**不会**主动请求定位权限或启动硬件，仅建立对 `locationPublisher` 的订阅；上层仍需确保 `CoreLocationKit` 已按需初始化并具有有效的定位权限。
+     - Requires: 需要在工程中集成 `CoreLocationKit` 与 `NavigationCoreKit`，并保证`CoreLocationKit.shared.locationPublisher()` 能够稳定推送 `CLLocation` 数据。
+     - Remark: 该方法适用于“快速接入”的场景，例如公路导航、骑行记录等，不需要自行管理海拔处理管线的应用。
+     - Note: 若对水平距离计算有更高精度要求（如基于轨迹纠偏、地图匹配等），建议**不要使用本默认管道**，而是在上层自行调用`ElevationManager.processAltitudeSample(rawAltitude:horizontalDistance:)` 进行更精细控制。
+     - Precondition: `CoreLocationKit.shared` 已完成初始化，且应用的 Info.plist 中已配置必要的定位权限字段（如 `NSLocationWhenInUseUsageDescription` 等）。
+     - Postcondition: 成功调用后，`ElevationManager` 将随位置更新自动计算：
+     - 平滑海拔（`smoothedAltitude`）
+     - 累计爬升（`elevationGain`）
+     - 累计下降（`elevationLoss`）
+     - 当前坡度（`gradient`，单位：百分比 %）
+     
+     # 使用示例
+     ```swift
+     // 在 App 启动或导航功能初始化时调用一次
+     NavigationKit.startDefaultElevationPipeline()
+     
+     // 在 ViewModel 中订阅计算结果
+     NavigationKit.elevationManager.$elevationGain
+     .receive(on: RunLoop.main)
+     .sink { gain in
+     print("当前累计爬升：\(gain) m")
+     }
+     .store(in: &subscriptions)
+     ```
+     
+     - parameter 无: 本方法不接受任何参数，内部直接使用 `CoreLocationKit.shared.locationPublisher()`（使用 SDK 默认精度/距离过滤参数）。
+     - Returns: 无返回值。
+     - Throws: 不抛出错误，所有异常情况通过日志或上层状态观察处理。
+     */
     public static func startDefaultElevationPipeline() {
         guard isElevationPipelineStarted == false else { return }
         isElevationPipelineStarted = true
         
-        CoreLocationKit.shared.locationPublisher
+        CoreLocationKit.shared.locationPublisher()
             .compactMap { $0 }
             .sink { location in
                 let altitude = location.altitude

--- a/Sources/NavigationKit/NavigationKit.swift
+++ b/Sources/NavigationKit/NavigationKit.swift
@@ -86,47 +86,47 @@ extension NavigationKit {
     }
     
     /**
-         停止默认的海拔计算数据管道，并重置相关内部状态。
-         
-         - Important: 调用本方法后，`NavigationKit` 将不再从 `CoreLocationKit` 接收位置更新，
-           默认海拔管道被完全关闭，直到再次调用 `startDefaultElevationPipeline()`。
-         - Attention: 本方法会调用 `ElevationManager.reset()`（需要在 `ElevationManager` 中提供实现），
-           用于清空平滑海拔、累计爬升/下降、坡度等内部统计，适合在“结束一次记录”或“重置状态”
-           的场景中使用。
-         - Bug: 若上层在仍需使用默认海拔管道时误调用本方法，将导致后续不再更新海拔与坡度数据，
-           需要重新调用 `startDefaultElevationPipeline()` 以恢复。
-         - Warning: 本方法会将 `subscriptions` 清空，意味着所有通过
-           `startDefaultElevationPipeline()` 建立的内部订阅都会被释放，无法恢复先前的状态。
-         - Requires: 应在确定当前不再需要默认海拔管道（例如停止轨迹记录、退出导航模式）时调用。
-         - Remark: 该方法不会影响上层自行构建的其它订阅逻辑，仅作用于
-           `NavigationKit` 内部维护的默认 Elevation 管道。
-         - Note:
-           - 如果你希望在不同“记录 Session”之间重用同一个 `ElevationManager` 实例，
-             推荐在每次开始新 Session 前调用一次 `stopElevationPipeline()`，
-             然后再调用 `startDefaultElevationPipeline()`，以保证统计数据干净。
-           - 如果你不希望在停止时清空历史统计，可在自定义版本中移除对 `reset()` 的调用。
-         - Precondition: `startDefaultElevationPipeline()` 曾被调用且当前处于已启动状态；
-           否则本方法将安静返回，不做任何操作。
-         - Postcondition:
-           - 默认海拔数据管道被完全停止；
-           - 内部订阅集合 `subscriptions` 被清空；
-           - `lastLocation` 被重置为 `nil`；
-           - `isElevationPipelineStarted` 被重置为 `false`；
-           - `elevationManager` 的内部统计算法状态被 `reset()` 清空（取决于你的实现）。
-         
-         # 使用示例
-         ```swift
-         // 结束一次骑行 / 导航记录时：
-         NavigationKit.stopElevationPipeline()
-         
-         // 再次开始新一段记录：
-         NavigationKit.startDefaultElevationPipeline()
-         ```
-         
-         - parameter 无: 本方法不接受任何参数。
-         - Returns: 无返回值。
-         - Throws: 不抛出错误。
-         */
+     停止默认的海拔计算数据管道，并重置相关内部状态。
+     
+     - Important: 调用本方法后，`NavigationKit` 将不再从 `CoreLocationKit` 接收位置更新，
+     默认海拔管道被完全关闭，直到再次调用 `startDefaultElevationPipeline()`。
+     - Attention: 本方法会调用 `ElevationManager.reset()`（需要在 `ElevationManager` 中提供实现），
+     用于清空平滑海拔、累计爬升/下降、坡度等内部统计，适合在“结束一次记录”或“重置状态”
+     的场景中使用。
+     - Bug: 若上层在仍需使用默认海拔管道时误调用本方法，将导致后续不再更新海拔与坡度数据，
+     需要重新调用 `startDefaultElevationPipeline()` 以恢复。
+     - Warning: 本方法会将 `subscriptions` 清空，意味着所有通过
+     `startDefaultElevationPipeline()` 建立的内部订阅都会被释放，无法恢复先前的状态。
+     - Requires: 应在确定当前不再需要默认海拔管道（例如停止轨迹记录、退出导航模式）时调用。
+     - Remark: 该方法不会影响上层自行构建的其它订阅逻辑，仅作用于
+     `NavigationKit` 内部维护的默认 Elevation 管道。
+     - Note:
+     - 如果你希望在不同“记录 Session”之间重用同一个 `ElevationManager` 实例，
+     推荐在每次开始新 Session 前调用一次 `stopElevationPipeline()`，
+     然后再调用 `startDefaultElevationPipeline()`，以保证统计数据干净。
+     - 如果你不希望在停止时清空历史统计，可在自定义版本中移除对 `reset()` 的调用。
+     - Precondition: `startDefaultElevationPipeline()` 曾被调用且当前处于已启动状态；
+     否则本方法将安静返回，不做任何操作。
+     - Postcondition:
+     - 默认海拔数据管道被完全停止；
+     - 内部订阅集合 `subscriptions` 被清空；
+     - `lastLocation` 被重置为 `nil`；
+     - `isElevationPipelineStarted` 被重置为 `false`；
+     - `elevationManager` 的内部统计算法状态被 `reset()` 清空（取决于你的实现）。
+     
+     # 使用示例
+     ```swift
+     // 结束一次骑行 / 导航记录时：
+     NavigationKit.stopElevationPipeline()
+     
+     // 再次开始新一段记录：
+     NavigationKit.startDefaultElevationPipeline()
+     ```
+     
+     - parameter 无: 本方法不接受任何参数。
+     - Returns: 无返回值。
+     - Throws: 不抛出错误。
+     */
     public static func stopElevationPipeline() {
         guard isElevationPipelineStarted else { return }
         

--- a/Sources/NavigationKit/NavigationKit.swift
+++ b/Sources/NavigationKit/NavigationKit.swift
@@ -13,7 +13,7 @@ import NavigationCoreKit
 
 public enum NavigationKit {
     /// NavigationKit 版本号
-    public static let version: String = "1.5.1(2026050)"
+    public static let version: String = "1.6.0(2026051)"
 }
 
 //MARK: - Elevation

--- a/Tests/NavigationKitTests/CoreLocationKitTests.swift
+++ b/Tests/NavigationKitTests/CoreLocationKitTests.swift
@@ -142,8 +142,8 @@ final class CoreLocationKitTests: XCTestCase {
         let kit = CoreLocationKit.shared
         let expectation = expectation(description: "locationPublisher 推送注入的位置")
         let mock = CLLocation(latitude: 31.23, longitude: 121.47)
-
-        kit.locationPublisher
+        
+        kit.locationPublisher()
             .compactMap { $0 }
             .dropFirst(0)
             .sink { location in
@@ -152,7 +152,7 @@ final class CoreLocationKitTests: XCTestCase {
                 }
             }
             .store(in: &subscriptions)
-
+        
         kit.locationManager(kit.locationManager, didUpdateLocations: [mock])
         wait(for: [expectation], timeout: 1)
     }


### PR DESCRIPTION
摘要

本次更新重构了 CoreLocationKit 的定位生命周期与参数管理，将定位精度和距离过滤的控制权从全局共享状态转移到具体定位请求和订阅方。这实现了机制与策略的分离，大幅提升了定位行为的灵活性和可预测性，并有效避免了不同调用方之间的参数冲突。

主要变化

- `CoreLocationKit` 的 `init` 不再自动请求授权或开始定位，变为完全被动状态。授权请求 `requestAuthorizationIfNeeded()` 现在需由调用方显式触发，且 `locationPublisher` 方法支持在订阅时指定精度和距离过滤参数。
- `locationPublisher` 从属性更改为方法 `locationPublisher(accuracy:distanceFilter:)`，允许在每次订阅时独立配置定位精度和距离过滤器，从而消除全局参数的副作用。
- `requestCurrentLocation` 方法新增 `accuracy` 参数，支持为单次定位请求定制精度。
- 移除了 `setLocationAccuracy` 方法及内部 `restartUpdatingLocation` 机制，强化了参数由调用方控制的理念。
- 将 `locationManager` 属性的访问权限调整为 `internal`，确保所有定位操作通过 SDK 的公共接口进行，以维护封装性。

解决的问题

- 解决了先前通过 `init` 或 `setLocationAccuracy` 设置的全局定位参数容易被不同调用方意外覆盖或影响的问题，避免了不一致的定位行为。
- 消除了在应用启动初期，瞬时读取授权状态可能得到假 `notDetermined` 的“空窗期”问题，通过异步等待授权就绪的方式提供更可靠的状态判断。

带来的好处

- **增强灵活性与控制:** 开发者现在可以根据具体的业务场景，为持续定位和单次定位提供更精细的参数控制。
- **提升模块解耦性:** 将定位策略从 CoreLocationKit 内部机制中分离，降低了模块间的耦合度。
- **提高可预测性:** 消除了全局共享状态可能带来的隐式副作用，使定位行为更透明、更易于调试。
- **优化能效管理:** 只有当存在活跃订阅者时才启动持续定位，无人订阅时停止，有助于减少不必要的电量消耗。

升级说明 

- 如果之前直接调用 `CoreLocationKit.shared.setLocationAccuracy(...)`，现在需要改为在订阅 `locationPublisher()` 或调用 `requestCurrentLocation(...)` 时传入相应的 `accuracy` 和 `distanceFilter` 参数。
- `CoreLocationKit.shared.locationPublisher` 已从属性变为方法，所有调用方需更新为 `CoreLocationKit.shared.locationPublisher()`。
- 如果之前依赖 `CoreLocationKit` 初始化时自动请求定位授权，现在需要显式调用 `CoreLocationKit.shared.requestAuthorizationIfNeeded()`。

验证方法

- 更新了 `CoreLocationKitTests.swift` 中的相关测试用例，以适应 `locationPublisher` 的新签名。
- 请通过运行现有单元测试和集成测试，确认定位行为在各种授权状态和参数配置下均符合预期。
